### PR TITLE
Change for adding a mixing to style input wrapper

### DIFF
--- a/paper-input-container.html
+++ b/paper-input-container.html
@@ -216,6 +216,7 @@ This element is `display:block` by default, but you can set the `inline` attribu
       .input-wrapper {
         @apply --layout-horizontal;
         @apply --layout-center;
+ 	@apply --paper-input-container-input-wrapper;
         position: relative;
       }
 


### PR DESCRIPTION
I have a requirement to display paper-dropdown-menu as a standard dropdown and not in material design. I need to do it through stylesheet as few of our customer still want to have old look/feel and we do not want to have custom coding instead trying to change the look/feel using styles. I am able to display paper-input like legacy elements easily by using paper-input-container styles but no luck with dropdown.